### PR TITLE
fix: make SettingsScene.update() dt parameter optional

### DIFF
--- a/src/scenes/settings.py
+++ b/src/scenes/settings.py
@@ -108,11 +108,11 @@ class SettingsScene:
 
         return None
 
-    def update(self, dt: float) -> None:
+    def update(self, dt: float = 0.0) -> None:
         """Update scene state.
 
         Args:
-            dt: Time delta in seconds.
+            dt: Time delta in seconds (optional, defaults to 0.0).
         """
         # Settings scene doesn't need animation updates
         pass


### PR DESCRIPTION
## Summary
Fixes crash when clicking the Settings button in the game.

## Problem
The SceneManager calls `update()` without parameters, but SettingsScene expected a required `dt` parameter, causing a TypeError:
```
TypeError: SettingsScene.update() missing 1 required positional argument: 'dt'
```

## Solution
Made the `dt` parameter optional with a default value of 0.0 to match the pattern used by other scenes like TitleScreen.

## Testing
- [x] Tested locally - settings button now works without crashing
- [x] Game runs normally with the fix

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>