### PR TITLE
fix: re-enable Windows runner in CI workflow

### DIFF
--- a/.github/workflows/game-ci.yaml
+++ b/.github/workflows/game-ci.yaml
@@ -110,8 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # TODO: Re-enable windows-latest once Poetry installation is fixed (see issue #54)
-        os: [ubuntu-latest, macos-latest]  # windows-latest temporarily disabled
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -146,10 +145,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # TODO: Re-enable Windows once Poetry installation is fixed (see issue #54)
-          # - os: windows-latest
-          #   name: Windows
-          #   artifact: DangerRose-Windows
+          - os: windows-latest
+            name: Windows
+            artifact: DangerRose-Windows
           - os: ubuntu-latest
             name: Linux
             artifact: DangerRose-Linux


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR re-enables the Windows runner in the CI workflow that was previously disabled due to Poetry installation issues.

## Changes
- **test-game job**: Added `windows-latest` back to the OS matrix
- **build-executables job**: Uncommented Windows build configuration
- Removed TODO comments about issue #54

## Impact
This restores full cross-platform CI/CD support:
- ✅ Windows tests will run in CI
- ✅ Windows executables will be built
- ✅ Windows artifacts will be available in releases

## Testing
The CI workflow will now:
1. Test the game on Windows, macOS, and Linux
2. Build executables for all three platforms
3. Create release artifacts for all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)