### PR TITLE
fix: handle Poetry installation on Windows runners

### DIFF
--- a/.github/workflows/game-ci.yaml
+++ b/.github/workflows/game-ci.yaml
@@ -110,8 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # TODO: Re-enable windows-latest once Poetry installation is fixed (see issue #54)
-        os: [ubuntu-latest, macos-latest]  # windows-latest temporarily disabled
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -127,17 +126,29 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Configure Poetry for Windows
+        if: runner.os == 'Windows'
+        run: |
+          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
+          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: |
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry install --no-interaction
+        shell: bash
 
       - name: Test game startup (headless)
         run: |
-          poetry run python -c "import pygame; pygame.init(); print('Pygame initialized successfully')"
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry run python -c "import pygame; pygame.init(); print('Pygame initialized successfully')"
+        shell: bash
 
       - name: Verify assets
         run: |
-          poetry run python -c "import os; import sys; assets_dir = 'assets'; required_dirs = ['audio/music', 'audio/sfx', 'images/characters', 'images/tilesets']; missing = []; [missing.append(os.path.join(assets_dir, d)) for d in required_dirs if not os.path.exists(os.path.join(assets_dir, d))]; print(f'Missing directories: {missing}') if missing else print('All asset directories present'); sys.exit(1) if missing else sys.exit(0)"
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry run python -c "import os; import sys; assets_dir = 'assets'; required_dirs = ['audio/music', 'audio/sfx', 'images/characters', 'images/tilesets']; missing = []; [missing.append(os.path.join(assets_dir, d)) for d in required_dirs if not os.path.exists(os.path.join(assets_dir, d))]; print(f'Missing directories: {missing}') if missing else print('All asset directories present'); sys.exit(1) if missing else sys.exit(0)"
+        shell: bash
 
   build-executables:
     name: Build Game Executables
@@ -146,10 +157,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # TODO: Re-enable Windows once Poetry installation is fixed (see issue #54)
-          # - os: windows-latest
-          #   name: Windows
-          #   artifact: DangerRose-Windows
+          - os: windows-latest
+            name: Windows
+            artifact: DangerRose-Windows
           - os: ubuntu-latest
             name: Linux
             artifact: DangerRose-Linux
@@ -171,13 +181,24 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Configure Poetry for Windows
+        if: runner.os == 'Windows'
+        run: |
+          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
+          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: |
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry install --no-interaction
+        shell: bash
 
       - name: Build with PyInstaller
         run: |
-          poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+        shell: bash
 
       - name: Create distribution folder
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,13 +38,23 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Configure Poetry for Windows
+        if: runner.os == 'Windows'
+        run: |
+          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
+          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: |
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry install --no-interaction
+        shell: bash
 
       - name: Build executable with PyInstaller
         run: |
-          poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+          python -m poetry run pyinstaller danger-rose-onefile.spec --noconfirm
 
       - name: Install Inno Setup
         shell: pwsh
@@ -148,13 +158,24 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Configure Poetry for Windows
+        if: runner.os == 'Windows'
+        run: |
+          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
+          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: |
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry install --no-interaction
+        shell: bash
 
       - name: Build with PyInstaller
         run: |
-          poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+          ${{ runner.os == 'Windows' && 'python -m' || '' }} poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+        shell: bash
 
       - name: Create distribution folder
         shell: bash


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR fixes the Poetry installation issues on Windows runners in GitHub Actions, resolving the "poetry command not found" error.

## Problem
On Windows runners, Poetry installs to a different location and isn't automatically added to the PATH, causing commands like `poetry install` to fail.

## Solution
- Add Windows-specific configuration step to add Poetry to PATH
- Use `python -m poetry` syntax on Windows runners
- Apply conditional logic to maintain cross-platform compatibility
- Update both `game-ci.yaml` and `release.yaml` workflows

## Changes
1. **Windows Poetry Configuration**: Added PowerShell step to configure PATH
2. **Conditional Commands**: Use `${{ runner.os == 'Windows' && 'python -m' || '' }}` syntax
3. **Shell Specification**: Explicitly set `shell: bash` for cross-platform commands
4. **Performance**: Added `installer-parallel: true` for faster installation

## Testing
The workflows now:
- ✅ Properly detect Windows environment
- ✅ Configure Poetry PATH on Windows
- ✅ Use appropriate command syntax per platform
- ✅ Maintain compatibility with Linux/macOS

This unblocks Windows builds and enables full cross-platform CI/CD support.

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)