### PR TITLE
fix: use proper shell for Poetry commands on Windows

### DIFF
--- a/.github/workflows/game-ci.yaml
+++ b/.github/workflows/game-ci.yaml
@@ -128,25 +128,39 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Configure Poetry PATH on Windows
+      - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
-        run: |
-          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
-          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # Verify poetry is accessible
-          where.exe poetry
+        run: poetry install --no-interaction
         shell: pwsh
 
-      - name: Install dependencies
+      - name: Install dependencies (Unix)
+        if: runner.os != 'Windows'
         run: poetry install --no-interaction
+        shell: bash
 
-      - name: Test game startup (headless)
+      - name: Test game startup (Windows)
+        if: runner.os == 'Windows'
         run: |
           poetry run python -c "import pygame; pygame.init(); print('Pygame initialized successfully')"
+        shell: pwsh
 
-      - name: Verify assets
+      - name: Test game startup (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          poetry run python -c "import pygame; pygame.init(); print('Pygame initialized successfully')"
+        shell: bash
+
+      - name: Verify assets (Windows)
+        if: runner.os == 'Windows'
         run: |
           poetry run python -c "import os; import sys; assets_dir = 'assets'; required_dirs = ['audio/music', 'audio/sfx', 'images/characters', 'images/tilesets']; missing = []; [missing.append(os.path.join(assets_dir, d)) for d in required_dirs if not os.path.exists(os.path.join(assets_dir, d))]; print(f'Missing directories: {missing}') if missing else print('All asset directories present'); sys.exit(1) if missing else sys.exit(0)"
+        shell: pwsh
+
+      - name: Verify assets (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          poetry run python -c "import os; import sys; assets_dir = 'assets'; required_dirs = ['audio/music', 'audio/sfx', 'images/characters', 'images/tilesets']; missing = []; [missing.append(os.path.join(assets_dir, d)) for d in required_dirs if not os.path.exists(os.path.join(assets_dir, d))]; print(f'Missing directories: {missing}') if missing else print('All asset directories present'); sys.exit(1) if missing else sys.exit(0)"
+        shell: bash
 
   build-executables:
     name: Build Game Executables
@@ -181,21 +195,27 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Configure Poetry PATH on Windows
+      - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
-        run: |
-          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
-          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # Verify poetry is accessible
-          where.exe poetry
+        run: poetry install --no-interaction
         shell: pwsh
 
-      - name: Install dependencies
+      - name: Install dependencies (Unix)
+        if: runner.os != 'Windows'
         run: poetry install --no-interaction
+        shell: bash
 
-      - name: Build with PyInstaller
+      - name: Build with PyInstaller (Windows)
+        if: runner.os == 'Windows'
         run: |
           poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+        shell: pwsh
+
+      - name: Build with PyInstaller (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+        shell: bash
 
       - name: Create distribution folder
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,20 +40,14 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Configure Poetry PATH on Windows
-        run: |
-          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
-          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # Verify poetry is accessible
-          where.exe poetry
-        shell: pwsh
-
       - name: Install dependencies
         run: poetry install --no-interaction
+        shell: pwsh
 
       - name: Build executable with PyInstaller
         run: |
           poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+        shell: pwsh
 
       - name: Install Inno Setup
         shell: pwsh
@@ -159,21 +153,27 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Configure Poetry PATH on Windows
+      - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
-        run: |
-          $env:Path = "$env:APPDATA\Python\Scripts;$env:Path"
-          echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # Verify poetry is accessible
-          where.exe poetry
+        run: poetry install --no-interaction
         shell: pwsh
 
-      - name: Install dependencies
+      - name: Install dependencies (Unix)
+        if: runner.os != 'Windows'
         run: poetry install --no-interaction
+        shell: bash
 
-      - name: Build with PyInstaller
+      - name: Build with PyInstaller (Windows)
+        if: runner.os == 'Windows'
         run: |
           poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+        shell: pwsh
+
+      - name: Build with PyInstaller (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          poetry run pyinstaller danger-rose-onefile.spec --noconfirm
+        shell: bash
 
       - name: Create distribution folder
         shell: bash


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR fixes the Poetry execution on Windows by using the appropriate shell (PowerShell) instead of trying to manually configure PATH.

## Root Cause
The `snok/install-poetry@v1` action already handles Poetry installation and PATH configuration correctly. The issue was that we were:
1. Trying to manually add Poetry to PATH (unnecessary)
2. Using bash shell on Windows where Poetry expects PowerShell

## Solution
- **Remove all PATH manipulation** - the action handles this
- **Use PowerShell (`pwsh`) on Windows** for all Poetry commands
- **Use bash on Unix systems** (Linux/macOS)
- **Separate steps by OS** for clarity

## Changes
### CI Workflow (`game-ci.yaml`)
- Split dependency installation and build steps by OS
- Use `shell: pwsh` for Windows
- Use `shell: bash` for Unix

### Release Workflow (`release.yaml`)
- Apply same pattern for cross-platform builds
- Ensure Windows installer build uses PowerShell

## Key Insight
The Poetry GitHub action installs Poetry correctly and adds it to PATH. We just need to use the right shell:
- Windows: PowerShell understands the Windows PATH
- Unix: Bash works as expected

This approach is simpler and more reliable than trying to manipulate PATH ourselves.

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)