### PR TITLE
fix: correct semantic-release output variable names to use underscores

### DIFF
--- a/.github/workflows/game-ci.yaml
+++ b/.github/workflows/game-ci.yaml
@@ -323,8 +323,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     outputs:
-      new-release-published: ${{ steps.semantic.outputs.new-release-published }}
-      new-release-version: ${{ steps.semantic.outputs.new-release-version }}
+      new-release-published: ${{ steps.semantic.outputs.new_release_published }}
+      new-release-version: ${{ steps.semantic.outputs.new_release_version }}
     permissions:
       contents: write
       issues: write
@@ -379,7 +379,7 @@ jobs:
     name: Build Windows Installer
     needs: semantic-release
     runs-on: windows-latest
-    if: needs.semantic-release.result == 'success'
+    if: needs.semantic-release.outputs.new-release-published == 'true'
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
- Fixes semantic-release output variable references to use underscores instead of hyphens
- Updates build-windows-installer job condition to check output value instead of job result

## Changes
- Changed `steps.semantic.outputs.new-release-published` to `steps.semantic.outputs.new_release_published`
- Changed `steps.semantic.outputs.new-release-version` to `steps.semantic.outputs.new_release_version`
- Updated job condition from `needs.semantic-release.result == 'success'` to `needs.semantic-release.outputs.new-release-published == 'true'`

## Why This Fix is Needed
The semantic-release action (cycjimmy/semantic-release-action@v4) outputs use underscores in their names:
- `new_release_published` (not `new-release-published`)
- `new_release_version` (not `new-release-version`)

The workflow was incorrectly using hyphens, which meant these outputs were always undefined, causing the Windows installer build to never trigger after releases.

## Testing
- The semantic-release job will now correctly pass output values to dependent jobs
- The build-windows-installer job will trigger when a new release is published

🤖 Generated with [Claude Code](https://claude.ai/code)