### PR TITLE
fix: comment out SetupIconFile to fix Windows installer build

### DIFF
--- a/.github/workflows/game-ci.yaml
+++ b/.github/workflows/game-ci.yaml
@@ -445,7 +445,7 @@ jobs:
           SolidCompression=yes
           OutputDir=installer_output
           OutputBaseFilename=DangerRose-Setup-${{ needs.semantic-release.outputs.new-release-version }}
-          SetupIconFile=assets\images\icon.ico
+          ; SetupIconFile=assets\images\icon.ico
           WizardStyle=modern
           ArchitecturesAllowed=x64
           ArchitecturesInstallIn64BitMode=x64


### PR DESCRIPTION
## Summary
- Fixes Windows installer build error by commenting out the SetupIconFile directive
- Resolves "Resource update error: Icon file is invalid" error in GitHub Actions

## Problem
The Windows installer build is failing in GitHub Actions with the error:
```
Resource update error: Icon file is invalid.
```

This is happening when Inno Setup tries to use the icon file specified in the SetupIconFile directive.

## Solution
Commenting out the SetupIconFile line allows the installer to build successfully. The installer will use the default icon instead.

## Changes
- Comment out `SetupIconFile=assets\images\icon.ico` in `.github/workflows/game-ci.yaml`

## Testing
- [x] Windows installer builds successfully in GitHub Actions
- [x] The installer uses the default icon (acceptable for now)
- [x] All other functionality remains intact

## Notes
This is a temporary fix to unblock the CI/CD pipeline. A proper fix would involve:
1. Ensuring the icon file exists in the correct location during build
2. Verifying the icon file format is compatible with Inno Setup
3. Testing with different icon formats if needed

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>