### PR TITLE
fix: remove non-existent LICENSE file from Windows installer

### DIFF
--- a/.github/workflows/game-ci.yaml
+++ b/.github/workflows/game-ci.yaml
@@ -461,7 +461,6 @@ jobs:
           Source: "dist\DangerRose.exe"; DestDir: "{app}"; Flags: ignoreversion
           Source: "assets\*"; DestDir: "{app}\assets"; Flags: ignoreversion recursesubdirs createallsubdirs
           Source: "README.md"; DestDir: "{app}"; Flags: ignoreversion
-          Source: "LICENSE"; DestDir: "{app}"; Flags: ignoreversion
 
           [Icons]
           Name: "{group}\Danger Rose"; Filename: "{app}\DangerRose.exe"


### PR DESCRIPTION
## Summary
- Fixes Windows installer build by removing reference to non-existent LICENSE file
- Prevents Inno Setup compilation errors during CI/CD workflow

## Changes
- Modified `.github/workflows/game-ci.yaml` to remove LICENSE file from Windows installer script
- The LICENSE file line was removed from the `[Files]` section of the Inno Setup configuration

## Testing
- [x] Verified LICENSE file does not exist in repository
- [x] Confirmed this is the only reference to LICENSE in the installer script
- [ ] CI build should now complete successfully

## Context
The Windows installer script was attempting to include a LICENSE file that doesn't exist in the repository. This was causing the Inno Setup compilation to fail during the GitHub Actions workflow.

---
🤖 Created with ai-github-pr-workflow