### PR TITLE
Fix character selection bug - Dad now spawns correctly

### DIFF
--- a/src/scene_manager.py
+++ b/src/scene_manager.py
@@ -103,9 +103,12 @@ class SceneManager:
 
             # Handle scene transitions
             if result == "start_game":
-                self.game_data["selected_character"] = (
-                    self.current_scene.selected_character
-                )
+                # Always prioritize newly selected character over saved data
+                new_character = self.current_scene.selected_character
+                if new_character:
+                    self.game_data["selected_character"] = new_character
+                    # Update save data immediately to persist the selection
+                    self.save_manager.set_selected_character(new_character)
                 # Transition to hub world
                 self.switch_scene(SCENE_HUB_WORLD)
             elif result == "vegas":

--- a/src/scenes/hub.py
+++ b/src/scenes/hub.py
@@ -223,10 +223,10 @@ class HubWorld:
 
     def on_enter(self, previous_scene: str | None, data: dict[str, Any]) -> None:
         """Called when entering the hub world."""
-        # Update selected character if coming from character select
-        if previous_scene == "character_select" and data.get("selected_character"):
-            self.selected_character = data["selected_character"]
-            self.scene_manager.game_data["selected_character"] = self.selected_character
+        # Update selected character from scene manager (handles both fresh selections and saves)
+        current_character = self.scene_manager.game_data.get("selected_character")
+        if current_character and current_character != self.selected_character:
+            self.selected_character = current_character
 
             # Recreate player with new character
             self.player = Player(


### PR DESCRIPTION
## Summary
- Fixed race condition where saved character data was overriding user's fresh character selection
- Dad character now spawns correctly when selected
- Resolves issue #99

## Problem
When selecting "Dad" on the character selection screen, the player would start as "Danger" in the apartment instead.

## Root Cause
A race condition in data initialization where:
1. Scene Manager loaded saved character from disk, overriding `game_data["selected_character"]`
2. User selection in title screen set `selected_character` locally
3. When starting the game, the old save data took precedence over the new selection

## Solution
- Enhanced scene transition logic in `src/scene_manager.py` (lines 105-113) to prioritize newly selected characters
- Improved hub world character handling in `src/scenes/hub.py` (lines 224-237) to refresh character data on entry
- Character selection now immediately persists to save manager

## Test Plan
- [x] Select "Dad" → Spawns as Dad in apartment
- [x] Select "Rose" → Spawns as Rose in apartment  
- [x] Select "Danger" → Spawns as Danger in apartment
- [x] Quit and restart → Selected character persists correctly

Fixes #99

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>